### PR TITLE
deps!: upgrade interface-transport to ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,18 +132,18 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-address-manager": "^1.0.2",
+    "@libp2p/interface-address-manager": "^1.0.3",
     "@libp2p/interface-connection": "^3.0.1",
     "@libp2p/interface-connection-manager": "^1.1.0",
     "@libp2p/interface-content-routing": "^1.0.2",
     "@libp2p/interface-dht": "^1.0.1",
     "@libp2p/interface-metrics": "^3.0.0",
-    "@libp2p/interface-peer-id": "^1.0.2",
+    "@libp2p/interface-peer-id": "^1.0.4",
     "@libp2p/interface-peer-routing": "^1.0.1",
-    "@libp2p/interface-peer-store": "^1.2.1",
+    "@libp2p/interface-peer-store": "^1.2.2",
     "@libp2p/interface-pubsub": "^2.1.0",
     "@libp2p/interface-registrar": "^2.0.3",
-    "@libp2p/interface-transport": "^1.0.3",
+    "@libp2p/interface-transport": "^2.0.0",
     "@libp2p/interfaces": "^3.0.3",
     "err-code": "^3.0.1",
     "interface-datastore": "^7.0.0"


### PR DESCRIPTION
Upgrader can now accept UpgraderOptions for outgoing streams.